### PR TITLE
Add API documentation for creating stocked fabric cuts

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,7 +2,12 @@
 
 A history of changes to the Trinity Apparel API.
 
+## 2025-04-22
+
+- Added API to [create stocked fabric cuts](#create-stocked-fabric-cut) to log usage of stocked fabrics on garments.
+
 ## 2023-11-16
+
 - Updated [get shipment detail](#get-shipment-detail) to include the shipment type (bulk or direct).
 - Added API to [get garment ship destination](#get-garment-ship-destination) which includes the shipping class and rack code.
 - Added API to [complete shipment](#complete-shipment) that completes a created shipment and adjusts the shipment and garment statuses accordingly.

--- a/source/includes/_manufacturers.md
+++ b/source/includes/_manufacturers.md
@@ -1529,6 +1529,57 @@ Pattern Measurement rules:
 | 403           | Not Authorized - You're not a factory                |
 | 409           | Unable to update the fabric. Reason provided in JSON |
 
+## Create Stocked Fabric Cut
+
+```shell
+curl -X POST "https://api.trinity-apparel.com/v1/manufacturer_fabric_cuts"
+  -H "Authorization Bearer: swaledale"
+```
+
+> The above command returns JSON structured like this:
+
+```json
+{
+  "id": 6,
+  "fabric_id": 1,
+  "garment_id": 123,
+  "length": "2.45",
+  "is_recut": false,
+  "updated_at": "2025-04-21T20:53:20.000Z",
+  "created_at": "2025-04-21T20:53:20.000Z"
+}
+```
+
+### Description
+
+This call tracks the length (in meters) of fabric that is cut from a bolt of stocked fabric in order to be used on a garment.
+
+### HTTP Request
+
+`POST https://api.trinity-apparel.com/v1/manufacturer_fabric_cuts`
+
+### Query Parameters
+
+| Parameter  | Default | Description                                                                                                             |
+| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| garment_id | N/A     | Garment ID                                                                                                              |
+| fabric_id  | N/A     | Fabric ID. Integer not String                                                                                           |
+| meters     | N/A     | Fabric length in meters                                                                                                 |
+| is_recut   | false   | Boolean. Denotes if this is a recut of the fabric due to an issue with the previous cut (flawed fabric, too short, etc) |
+
+### Other
+
+- Permissions: Only manufacturers can access this route.
+- Pagination: N/A
+
+### Responses
+
+| Response Code | Description                                                     |
+| ------------- | --------------------------------------------------------------- |
+| 201           | Stocked fabric cut entry was created                            |
+| 403           | Error: Not Authorized - You're not a factory                    |
+| 409           | Error: Unable to create a fabric cut. Error message is provided |
+
 ## Create Fabric Cut
 
 ```shell


### PR DESCRIPTION
This pull request introduces a new API endpoint to create and log stocked fabric cuts, along with corresponding documentation updates. The changes enhance the Trinity Apparel API by enabling manufacturers to track fabric usage for garments.

### New API Endpoint:
* **`POST /v1/manufacturer_fabric_cuts`**: Added a new API for manufacturers to log fabric cuts from stocked fabrics. This includes details such as garment ID, fabric ID, length, and whether the cut is a recut. The endpoint is restricted to manufacturers and provides appropriate response codes for success and errors.

### Documentation Updates:
* **Changelog (`source/includes/_changelog.md`)**: Updated to include the addition of the new API for creating stocked fabric cuts.
* **Manufacturers Documentation (`source/includes/_manufacturers.md`)**: Added detailed documentation for the new API, including example usage, query parameters, permissions, and response structure.