### PR TITLE
Update fabric cut API documentation to replace fabric_id with sku_id …

### DIFF
--- a/source/includes/_manufacturers.md
+++ b/source/includes/_manufacturers.md
@@ -1541,7 +1541,7 @@ curl -X POST "https://api.trinity-apparel.com/v1/manufacturer_fabric_cuts"
 ```json
 {
   "id": 6,
-  "fabric_id": 1,
+  "sku_id": 1,
   "garment_id": 123,
   "length": "2.45",
   "is_recut": false,
@@ -1560,12 +1560,12 @@ This call tracks the length (in meters) of fabric that is cut from a bolt of sto
 
 ### Query Parameters
 
-| Parameter  | Default | Description                                                                                                             |
-| ---------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
-| garment_id | N/A     | Garment ID                                                                                                              |
-| fabric_id  | N/A     | Fabric ID. Integer not String                                                                                           |
-| meters     | N/A     | Fabric length in meters                                                                                                 |
-| is_recut   | false   | Boolean. Denotes if this is a recut of the fabric due to an issue with the previous cut (flawed fabric, too short, etc) |
+| Parameter       | Default | Description                                                                                                             |
+| --------------- | ------- | ----------------------------------------------------------------------------------------------------------------------- |
+| garment_id      | N/A     | Garment ID                                                                                                              |
+| supplier_number | N/A     | Supplier number of cut fabric                                                                                           |
+| meters          | N/A     | Fabric length in meters                                                                                                 |
+| is_recut        | false   | Boolean. Denotes if this is a recut of the fabric due to an issue with the previous cut (flawed fabric, too short, etc) |
 
 ### Other
 


### PR DESCRIPTION
This pull request updates the API documentation for the `manufacturer_fabric_cuts` endpoint in `source/includes/_manufacturers.md`. The changes include replacing the `fabric_id` parameter with `sku_id`, updating query parameters, and improving parameter descriptions.

### Updates to API documentation:

* Replaced the `fabric_id` field with `sku_id` in the JSON payload example to reflect updated terminology. (`source/includes/_manufacturers.md`, [source/includes/_manufacturers.mdL1544-R1544](diffhunk://#diff-b0b5b640fd0ce5e3e8cd40bd37dca35018a16fc47311eb74a09fa32d37518dddL1544-R1544))
* Updated the query parameters table:
  - Removed the `fabric_id` parameter and its description.
  - Added a new parameter, `supplier_number`, to track the supplier of the cut fabric. (`source/includes/_manufacturers.md`, [source/includes/_manufacturers.mdL1564-R1566](diffhunk://#diff-b0b5b640fd0ce5e3e8cd40bd37dca35018a16fc47311eb74a09fa32d37518dddL1564-R1566))